### PR TITLE
Support for missing/empty x-rainer-comment header

### DIFF
--- a/src/main/scala/com/metamx/rainer/http/RainerServlet.scala
+++ b/src/main/scala/com/metamx/rainer/http/RainerServlet.scala
@@ -65,10 +65,12 @@ trait RainerServlet[ValueType] extends ScalatraServlet with RainerServletBase wi
       if (request.header("X-Rainer-Version").exists(_ != version.toString)) {
         throw new ClientException("X-Rainer-Version must match URL version, or be omitted")
       }
-      (request.header("X-Rainer-Author"), request.header("X-Rainer-Comment")) match {
-        case (None, _) => BadRequest("Missing header: X-Rainer-Author")
-        case (_, None) => BadRequest("Missing header: X-Rainer-Comment")
-        case (Some(author), Some(comment)) =>
+      request.header("X-Rainer-Author") match {
+        case None => BadRequest("Missing header: X-Rainer-Author")
+
+        case Some(author) =>
+          val comment = request.header("X-Rainer-Comment").getOrElse("")
+
           val empty = RainerServlet.yesNo(request.header("X-Rainer-Empty").getOrElse("false")) getOrElse {
             throw new ClientException("Malformed header: X-Rainer-Empty")
           }

--- a/src/test/scala/com/metamx/rainer/test/ServletTest.scala
+++ b/src/test/scala/com/metamx/rainer/test/ServletTest.scala
@@ -456,6 +456,48 @@ class ServletTest extends Matchers with RainerTests
   }
 
   @Test
+  def testPostMissingComment() {
+    execute {
+      tester =>
+        tester.post("/things/what/1", """{"s":"hey"}""".getBytes, Map(
+          "X-Rainer-Author" -> "dude"
+        )) {
+          Jackson.parse[Dict](tester.body) must be(
+            Map(
+              "key" -> "what",
+              "version" -> 1,
+              "author" -> "dude",
+              "comment" -> "",
+              "mtime" -> "1970-01-01T00:00:00.002Z",
+              "empty" -> false
+            )
+          )
+          tester.status must be(200)
+        }
+    }
+
+    execute {
+      tester =>
+        tester.post("/things/what/1", """{"s":"hey"}""".getBytes, Map(
+          "X-Rainer-Author" -> "dude",
+          "X-Rainer-Comment" -> ""
+        )) {
+          Jackson.parse[Dict](tester.body) must be(
+            Map(
+              "key" -> "what",
+              "version" -> 1,
+              "author" -> "dude",
+              "comment" -> "",
+              "mtime" -> "1970-01-01T00:00:00.002Z",
+              "empty" -> false
+            )
+          )
+          tester.status must be(200)
+        }
+    }
+  }
+
+  @Test
   def testGetMirror() {
     executeMirror {
       tester =>


### PR DESCRIPTION
Jetty 9.2.X returns null if the HTTP header has empty value, while Jetty 8 we used before was returning blank. Pyrainer uses empty string if comment is not supplied, so we need to support this in RainerServlet.

Some details on Jetty implementation could be found here: http://dev.eclipse.org/mhonarc/lists/jetty-users/msg03339.html 